### PR TITLE
Fix the converged flag: a stalled fit is not a converged one

### DIFF
--- a/src/core/optimizer/eigen_levenberg.cpp
+++ b/src/core/optimizer/eigen_levenberg.cpp
@@ -107,6 +107,7 @@ int NonlinearFit(QWeakPointer<AbstractModel> model, QVector<qreal>& param, QVect
     Eigen::VectorXd parameter(param.size());
     for (int i = 0; i < param.size(); ++i)
         parameter(i) = param[i];
+    const Eigen::VectorXd parameter_initial = parameter; // reference point for the "never moved" test below
 
     MyFunctor functor(param.size(), ModelSignals.size());
     functor.model = model;
@@ -155,7 +156,16 @@ int NonlinearFit(QWeakPointer<AbstractModel> model, QVector<qreal>& param, QVect
     // AND parameter step below DeltaParameter), NOT merely "iter < MaxIter". The old proxy
     // falsely reported a fit that reached the minimum exactly at the iteration limit as
     // not-converged (see the diagnostics behind the InitialGuess root-cause).
-    const bool converged = (qAbs(error_0 - error_2) <= ErrorConvergence) && (norm <= DeltaParameter);
+    //
+    // Both criteria are also trivially satisfied by a solver that never left its start value - a
+    // stall then reports success at whatever SSE the start happened to have. The gradient tells the
+    // two apart: lm.gnorm is MINPACK's scaled gradient (a cosine, hence dimensionless), ~0 at a
+    // stationary point and O(1) at a point the solver merely failed to leave. It is therefore
+    // required only where nothing moved; a fit that did move keeps the criteria above unchanged.
+    const bool settled = (qAbs(error_0 - error_2) <= ErrorConvergence) && (norm <= DeltaParameter);
+    const bool moved = (parameter - parameter_initial).cwiseAbs().sum() > DeltaParameter;
+    const bool stationary = lm.gnorm <= config["LevMar_Gtol"].toDouble();
+    const bool converged = settled && (moved || stationary);
     model.toStrongRef()->setConverged(converged);
     return iter;
 }

--- a/src/core/optimizer/varpro_levenberg.cpp
+++ b/src/core/optimizer/varpro_levenberg.cpp
@@ -163,8 +163,14 @@ int VarProFit(QWeakPointer<AbstractModel> weak, QVector<double>& sse_history, QV
             lambda = std::min(lambda * 3.0, 1e12);
         }
 
-        if (!improved)
-            break; // sitting in a (local) minimum: no downhill step found
+        if (!improved) {
+            // No step reduced the SSE although lambda was escalated to 1e12, i.e. the solver sits in
+            // a (local) minimum. That IS convergence: leaving the flag false here reported an exact
+            // fit - one that reached the optimum so closely that no downhill direction remains - as
+            // a failed one. A non-finite SSE is the genuine failure and stays not-converged.
+            converged = std::isfinite(sse);
+            break;
+        }
 
         const double sseChange = std::abs(sse - trialSse);
         const double stepNorm = (trialBeta - beta).cwiseAbs().sum();


### PR DESCRIPTION
Both solvers derived `isConverged()` from criteria that a stalled run satisfies trivially — in opposite directions, so the flag read backwards in both failure modes.

**LevMar** (`eigen_levenberg.cpp`) stops when neither the SSE nor the parameters change. That is also true of a run that never left its start value, so sitting on the initial guess was reported as success. The scaled gradient (`lm.gnorm`, a dimensionless cosine, ~0 at a stationary point and O(1) at a point the solver merely failed to leave) separates the two cases. It is now required only where nothing moved; a fit that did move keeps the previous criteria unchanged.

**VarPro** (`varpro_levenberg.cpp`) left the flag false when no downhill step existed after escalating lambda to 1e12 — which is a local minimum, i.e. exactly what the flag is supposed to report. A non-finite SSE remains not-converged.

### Evidence

`benchmark_dimer_flat` (6 configurations, release build — a 1:1/1:2 truth fitted with a spurious dimerisation, so the model carries a direction the data cannot constrain):

- **SSE and every recovered parameter are unchanged in all 12 rows.** Only the flag moves.
- It moves in both directions: the two LevMar rows that sat on their start (SSE 2.53 and 11.1, parameters untouched) go from `converged` to not; the VarPro rows that land exactly on the truth (3.8000 / 5.9000 at SSE 6.7e-11 and 2.2e-10) go from not-converged to converged.
- The row that runs into the iteration limit with a wrong result stays not-converged.

`test_varpro` 17/17, `test_varpro_cv`, and the model suite are unchanged; `ReferenceProjectsTest` keeps its two known 2:1/1:1 failures, unaffected by this change.

Note that convergence is not correctness: one VarPro row now reports converged at a wrong lg β12. It did converge — to a bad local minimum. The flag claims only the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)