### PR TITLE
CI: sign the macOS bundle after deployment

### DIFF
--- a/scripts/build_macOS_github.sh
+++ b/scripts/build_macOS_github.sh
@@ -11,4 +11,8 @@ cmake -DCMAKE_BUILD_TYPE=Release -Dnoto_font=true -D_Theme=false  ..
 # Build only the deployed executables (not the test suite); -j2 for stable peak RAM.
 make -j2 suprafit suprafit_cli
 cd bin/macOS
-macdeployqt  suprafit.app -dmg
+# -codesign=- re-signs the bundle ad-hoc after deployment. Without it the app keeps only the
+# linker-signed signature, which seals no resources - while macdeployqt copies SupraFit.icns into
+# Contents/Resources. A bundle in that state fails `codesign --verify --deep` with "code has no
+# resources but signature indicates they must be present", which blocked the artifact upload.
+macdeployqt  suprafit.app -codesign=- -dmg


### PR DESCRIPTION
The macOS job has been failing at `Verify app signing and macOS assessment`, which skips artifact collection — so the `nightly` release still serves a dmg built on 2026-07-07 while its tag has moved on twice.

`macdeployqt` copies `SupraFit.icns` into `Contents/Resources` but leaves the bundle on its linker-signed ad-hoc signature, which seals no resources:

```
CodeDirectory v=20400 flags=0x20002(adhoc,linker-signed)
Sealed Resources=none
suprafit.app: code has no resources but signature indicates they must be present
```

`-codesign=-` makes macdeployqt re-sign the bundle after deployment, which writes a proper `_CodeSignature/CodeResources`. The verification step then checks a signature that matches the bundle instead of being turned off.

Removing `--strict` (PR #8) did not help — the mismatch is in the signature, not in the strictness of the check. PR #8 can be closed once this lands.

Only CI can verify this: there is no macOS machine on this side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)