### PR TITLE
Docs: state which results change with the BC50 work

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 # The (incomplete) SupraFit Changelog
 
 ### SupraFit 2.x
+- BC50 for the reaction-defined models is derived from the model's stoichiometry instead of the 1:1 formula
+- BC50 in grid-search output for all ITC models, over the correct interval
+- the 2:1/1:1 models solve the cubic mass balance in closed form
+- reworked engine for scripted models: the equation is compiled once, supports per-series parameters, and can call the equilibrium solver and the cubic and quadratic roots directly
+- the scripted-model dialog derives the parameter declaration from the equation
 - Python interface (`import suprafit`), off by default, built with `-DSUPRAFIT_PYBIND=ON`
 - thermogram import shows the full precision of the core instead of six significant digits
 - a fit stuck on its start value is no longer reported as converged

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Latest snapshots (not more than 5) of the current development can be found via t
 - The current master branch contains the thermogram import routed through the core, developed in the **refactor/thermo-gui-routing** branch. The import dialog now shows the full precision that the command line has always read, so its volume and heat columns display more digits than before. The last binaries without this change are [2.5.139](https://github.com/conradhuebler/SupraFit/releases/tag/2.5.139).
 - The current master branch contains a Python interface (`import suprafit`), developed in the **feature/python-interface** branch. It is not part of the binaries above and has to be built with `-DSUPRAFIT_PYBIND=ON`; see [python/README.md](https://github.com/conradhuebler/SupraFit/blob/master/python/README.md).
 
+- The current master branch contains a reworked engine for scripted models and a corrected BC50 calculation, developed in the **feature/scripted-model-engine** branch. The last binaries without these changes are [2.5.139](https://github.com/conradhuebler/SupraFit/releases/tag/2.5.139).
+
+**Results that change with this version.** BC50 for the reaction-defined models (`nmr_any`, `uvvis_any`, `fl_any`, `itc_any`) was calculated from the 1:1 formula regardless of the reaction system that was loaded, and is now derived from the model's own stoichiometry. Grid-search output shows BC50 for the remaining ITC models and over the correct interval — the previous code collapsed that interval to a single point. The 2:1/1:1 models solve the cubic mass balance in closed form, which the previous solver did not satisfy exactly, so refitting such a model can land on slightly different constants. Values stored in a project file are not rewritten until you refit. To reproduce earlier numbers, use [2.5.139](https://github.com/conradhuebler/SupraFit/releases/tag/2.5.139).
+
 A fit that stops without moving off its start value is no longer reported as converged, and a fit that reaches the optimum exactly now is. This changes the flag shown next to a result, not the result itself.
 
 ## Usage


### PR DESCRIPTION
Completes the README pass now that the scripted-model branch has landed. Adds the third "Nightly Build" bullet in the same house style, and one paragraph naming what a user will actually see differ:

- BC50 for the reaction-defined models came from the 1:1 formula regardless of the reaction system that was loaded, and now comes from the model's own stoichiometry.
- Grid-search output shows BC50 for the remaining ITC models, over an interval that the previous code collapsed to a single point.
- The 2:1/1:1 models changed concentration solver — so a **refit** can land on slightly different constants, not only a different BC50. Stored values are not rewritten until you refit.
- 2.5.139 is named as the way to reproduce earlier numbers.

An earlier draft of that paragraph claimed the fitted binding constants were unaffected. They are not: the reference SSE of the 2:1/1:1 model moved by 0.13 %, which is the solver change rather than noise.

Docs only — `README.md` and `Changelog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)