### PR TITLE
Docs and citations: refresh the stale README entries, credit Equilibrist, skip CI for markdown-only changes

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -3,7 +3,11 @@ name: Build
 on:
   push:
     branches: [ master, "feature/**" ] # master: build + publish nightly; feature/*: build only
+    # Documentation-only changes cannot affect the binaries, so they do not rebuild three platforms.
+    # Note the consequence: a commit touching *only* markdown does not refresh the nightly release.
+    paths-ignore: [ '**.md' ]
   pull_request: # build only (no release) for all PR targets
+    paths-ignore: [ '**.md' ]
   workflow_dispatch:
 
 # The default GITHUB_TOKEN is read-only since 2023; publishing a release needs write.

--- a/README.md
+++ b/README.md
@@ -42,13 +42,11 @@ The content of the dmg file has to be copied to the place where other programs a
 ### Nightly Build
 Latest snapshots (not more than 5) of the current development can be found via the preleases. There are some new features and bugs included.
 
-- Custom models are work in progress and not yet well documented. For the start, please have a look at [here](https://github.com/conradhuebler/SupraFit/blob/master/docs/ScriptedModels.md) (Qt 6)
-- The current master branch contains a snapshot of an improved  thermogram handling, that was developed in the **thermogram** branch. The latest commit without the new branch is [dec3510](https://github.com/conradhuebler/SupraFit/commit/2211c62a327ea8a97c3960229837b44ee1c98511). (Qt 5)
-- The current master branch contains a snaphsot of a spectra import interface.  The latest commit without the new branch is [b5af8cd](https://github.com/conradhuebler/SupraFit/commit/b5af8cd9e8c29792c15b893aee8bcffa8a19dd8d). (Qt 5)
+- Models can be defined by writing the equation yourself instead of picking a built-in one — see [docs/ScriptedModels.md](https://github.com/conradhuebler/SupraFit/blob/master/docs/ScriptedModels.md). The equation is compiled once, may use per-series parameters, and can call the equilibrium solver and the cubic and quadratic roots directly.
+- Binding models are no longer limited to fixed stoichiometries: an equilibrium is entered as free-text reaction equations (`A + B <=> AB`, `2 A <=> A2`, `A + AB <=> A2B`) and solved for arbitrary components. The `nmr_any`, `uvvis_any`, `fl_any` and `itc_any` models are built on it.
 - The current master branch contains the thermogram import routed through the core, developed in the **refactor/thermo-gui-routing** branch. The import dialog now shows the full precision that the command line has always read, so its volume and heat columns display more digits than before. The last binaries without this change are [2.5.139](https://github.com/conradhuebler/SupraFit/releases/tag/2.5.139).
-- The current master branch contains a Python interface (`import suprafit`), developed in the **feature/python-interface** branch. It is not part of the binaries above and has to be built with `-DSUPRAFIT_PYBIND=ON`; see [python/README.md](https://github.com/conradhuebler/SupraFit/blob/master/python/README.md).
-
 - The current master branch contains a reworked engine for scripted models and a corrected BC50 calculation, developed in the **feature/scripted-model-engine** branch. The last binaries without these changes are [2.5.139](https://github.com/conradhuebler/SupraFit/releases/tag/2.5.139).
+- The current master branch contains a Python interface (`import suprafit`), developed in the **feature/python-interface** branch. It is not part of the binaries above and has to be built with `-DSUPRAFIT_PYBIND=ON`; see [python/README.md](https://github.com/conradhuebler/SupraFit/blob/master/python/README.md).
 
 **Results that change with this version.** BC50 for the reaction-defined models (`nmr_any`, `uvvis_any`, `fl_any`, `itc_any`) was calculated from the 1:1 formula regardless of the reaction system that was loaded, and is now derived from the model's own stoichiometry. Grid-search output shows BC50 for the remaining ITC models and over the correct interval — the previous code collapsed that interval to a single point. The 2:1/1:1 models solve the cubic mass balance in closed form, which the previous solver did not satisfy exactly, so refitting such a model can land on slightly different constants. Values stored in a project file are not rewritten until you refit. To reproduce earlier numbers, use [2.5.139](https://github.com/conradhuebler/SupraFit/releases/tag/2.5.139).
 
@@ -211,9 +209,13 @@ If the Monte Carlo simulation and Resampling plans were helpfull:
 
 ### Methods and references
 
-The general BFGS equilibrium speciation solver (arbitrary stoichiometry including self-aggregation, e.g. host dimerisation preceding complex formation) implements the method of:
+Equilibrium concentrations for an arbitrary set of reactions — including self-aggregation, such as a host dimerisation preceding complex formation — are obtained by minimising a convex potential in logarithmic concentration space. SupraFit took that approach from:
 
 - Daniil O. Soloviev and Christopher A. Hunter, *Musketeer: a software tool for the analysis of titration data*, Chem. Sci., 2024, **15**, 15299–15310. DOI [10.1039/d4sc03354j](https://doi.org/10.1039/d4sc03354j)
+
+The solver defaults to a damped Newton step with the analytic Hessian; the quasi-Newton (BFGS) variant remains selectable. Both reach the mass balance to 1e-12, which the solver's test pins.
+
+Models are told which references apply to them at runtime: a model whose equilibrium is solved this way names both this work and SupraFit in its model information.
 
 
 ### Poster presentation at Physical-Organic Chemistry at its Best: The Art of Chemical Problem Solving (13.09 and 14.09 2018)

--- a/README.md
+++ b/README.md
@@ -209,13 +209,14 @@ If the Monte Carlo simulation and Resampling plans were helpfull:
 
 ### Methods and references
 
-Equilibrium concentrations for an arbitrary set of reactions — including self-aggregation, such as a host dimerisation preceding complex formation — are obtained by minimising a convex potential in logarithmic concentration space. SupraFit took that approach from:
+Equilibrium concentrations for an arbitrary set of reactions — including self-aggregation, such as a host dimerisation preceding complex formation — are obtained by minimising a convex potential in logarithmic concentration space. Two programs that treat titration data this way were the inspiration for SupraFit's solver, and both deserve the credit:
 
 - Daniil O. Soloviev and Christopher A. Hunter, *Musketeer: a software tool for the analysis of titration data*, Chem. Sci., 2024, **15**, 15299–15310. DOI [10.1039/d4sc03354j](https://doi.org/10.1039/d4sc03354j)
+- Eric Masson, *Equilibrist: A Browser-Based Platform for Fitting Equilibrium and Rate Constants from Optical and NMR Data*, J. Chem. Inf. Model., 2026. DOI [10.1021/acs.jcim.6c01004](https://doi.org/10.1021/acs.jcim.6c01004)
 
-The solver defaults to a damped Newton step with the analytic Hessian; the quasi-Newton (BFGS) variant remains selectable. Both reach the mass balance to 1e-12, which the solver's test pins.
+SupraFit's own solver defaults to a damped Newton step with the analytic Hessian; the quasi-Newton (BFGS) variant remains selectable. Both reach the mass balance to 1e-12, which the solver's test pins.
 
-Models are told which references apply to them at runtime: a model whose equilibrium is solved this way names both this work and SupraFit in its model information.
+A model whose equilibrium is solved this way names both works, alongside SupraFit, in its model information — so the citation appears where the method was actually used.
 
 
 ### Poster presentation at Physical-Organic Chemistry at its Best: The Art of Chemical Problem Solving (13.09 and 14.09 2018)

--- a/src/core/citations.cpp
+++ b/src/core/citations.cpp
@@ -36,6 +36,10 @@ static const QVector<Reference>& registry()
             QStringLiteral("D. O. Soloviev, C. A. Hunter, Musketeer: a software tool for the analysis "
                            "of titration data, Chem. Sci. 2024, 15, 15299-15310."),
             QStringLiteral("10.1039/d4sc03354j") },
+        { QStringLiteral("equilibrist"),
+            QStringLiteral("E. Masson, Equilibrist: A Browser-Based Platform for Fitting Equilibrium "
+                           "and Rate Constants from Optical and NMR Data, J. Chem. Inf. Model. 2026."),
+            QStringLiteral("10.1021/acs.jcim.6c01004") },
     };
     return refs;
 }

--- a/src/core/models/titrations/AbstractTitrationModel.h
+++ b/src/core/models/titrations/AbstractTitrationModel.h
@@ -155,12 +155,13 @@ public:
 
     virtual QString ModelInfo() const override;
 
-    // Adds the Musketeer citation once speciation ran through the BFGS engine. Claude Generated.
+    // Names the two programs whose approach the speciation solver follows, once it actually ran.
+    // Claude Generated.
     inline QStringList CitationKeys() const override
     {
         QStringList keys;
         if (m_uses_bfgs)
-            keys << QStringLiteral("musketeer");
+            keys << QStringLiteral("musketeer") << QStringLiteral("equilibrist");
         return keys;
     }
 

--- a/src/core/models/titrations/itc/itc_any_Model.h
+++ b/src/core/models/titrations/itc/itc_any_Model.h
@@ -91,8 +91,12 @@ public:
     QString ModelInfo() const override;
     BC50::ModelSystem BC50System() const override;
 
-    // itc_any always drives speciation through the BFGS engine -> cite Musketeer. Claude Generated.
-    inline QStringList CitationKeys() const override { return QStringList() << QStringLiteral("musketeer"); }
+    // itc_any always drives speciation through the solver, so both its references always apply.
+    // Claude Generated.
+    inline QStringList CitationKeys() const override
+    {
+        return QStringList() << QStringLiteral("musketeer") << QStringLiteral("equilibrist");
+    }
     inline bool UseDynamicParameterWidget() const override { return true; }
     inline virtual bool DemandInput() const { return true; }
 

--- a/src/tests/test_nmr_ncomponent.cpp
+++ b/src/tests/test_nmr_ncomponent.cpp
@@ -122,10 +122,12 @@ private slots:
         model->setGlobalParameter(3.5, 1); // lg beta(AC)
         model->Calculate();
 
-        // runtime citation: a BFGS-driven model must ask to cite Musketeer alongside SupraFit
+        // runtime citation: a solver-driven model must ask to cite both source programs alongside SupraFit
         QVERIFY(model->CitationKeys().contains("musketeer"));
+        QVERIFY(model->CitationKeys().contains("equilibrist"));
         const QString cite = model->CitationBlock();
         QVERIFY(cite.contains("Musketeer"));
+        QVERIFY(cite.contains("Equilibrist"));
         QVERIFY(cite.contains("SupraFit"));
 
         for (int i = 1; i < N; ++i) {


### PR DESCRIPTION
### Citations

SupraFit's equilibrium speciation solver was inspired by two programs, but only one of them was credited. Both are now named, in the README **and** in the runtime citation registry — so a model whose equilibrium actually went through the solver lists both in its model information, next to SupraFit itself:

- Daniil O. Soloviev and Christopher A. Hunter, *Musketeer: a software tool for the analysis of titration data*, Chem. Sci. 2024, **15**, 15299–15310. DOI 10.1039/d4sc03354j
- Eric Masson, *Equilibrist: A Browser-Based Platform for Fitting Equilibrium and Rate Constants from Optical and NMR Data*, J. Chem. Inf. Model. 2026. DOI 10.1021/acs.jcim.6c01004

Both citations were verified against Crossref. The Equilibrist article went online on 2026-07-23 and has no volume or page numbers yet. `test_nmr_ncomponent` pins both keys and both names in the citation block.

The description around the reference was also outdated: it called the solver "the general BFGS equilibrium speciation solver", but BFGS has not been the default since 2026-07-11 (a damped Newton with the analytic Hessian is), and the class no longer carries that name. It now separates what SupraFit took from that work from what its own solver does.

### README

Two "Nightly Build" entries described snapshots taken from the **thermogram** and spectra-import branches, marked *(Qt 5)*, pointing at commits from 2020 and 2022. Both have been ordinary parts of the program for years. They are replaced by what a reader currently wants to know: that models can be written as an equation instead of picked from a list, and that binding models are not limited to fixed stoichiometries. The "Custom models are work in progress and not yet well documented" line went with them.

### CI

Markdown-only pushes and pull requests no longer build three platforms. The trade-off is written into the workflow rather than left to be discovered: a commit touching only markdown does not refresh the nightly release either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)